### PR TITLE
Fix GET routing for phrases and subcategories

### DIFF
--- a/ServidorCode
+++ b/ServidorCode
@@ -105,24 +105,39 @@ class WebRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         """Processar requisições GET"""
         try:
-            if self.path == '/':
+            parsed_url = urllib.parse.urlparse(self.path)
+            path = parsed_url.path
+            path_parts = [part for part in path.split('/') if part]
+
+            if path == '/':
                 self.send_medical_interface()
-            elif self.path == '/api/categorias':
+            elif path == '/api/categorias':
                 categorias = self.automation_server.get_categorias_principais()
                 self.send_json_response(categorias)
-            elif self.path.startswith('/api/subcategorias/'):
-                categoria = urllib.parse.unquote(self.path.split('/')[-1])
-                subcategorias = self.automation_server.get_subcategorias(categoria)
-                self.send_json_response(subcategorias)
-            elif self.path.startswith('/api/frases/'):
-                parts = self.path.split('/')
-                if len(parts) >= 4:
-                    categoria = urllib.parse.unquote(parts[3])
-                    subcategoria = urllib.parse.unquote(parts[4]) if len(parts) > 4 else None
-                    frases = self.automation_server.get_frases(categoria, subcategoria)
+            elif len(path_parts) >= 2 and path_parts[0] == 'api' and path_parts[1] == 'subcategorias':
+                if len(path_parts) == 2:
+                    self.send_error(400, "Categoria não especificada")
+                else:
+                    categoria = urllib.parse.unquote('/'.join(path_parts[2:]))
+                    if not categoria:
+                        self.send_error(400, "Categoria não especificada")
+                    else:
+                        subcategorias = self.automation_server.get_subcategorias(categoria)
+                        self.send_json_response(subcategorias)
+            elif len(path_parts) >= 2 and path_parts[0] == 'api' and path_parts[1] == 'frases':
+                if len(path_parts) == 2:
+                    query_params = urllib.parse.parse_qs(parsed_url.query)
+                    categoria = query_params.get('categoria', [None])[0]
+                    subcategoria = query_params.get('subcategoria', [None])[0]
+                    frases = self.automation_server.get_frases(categoria or None, subcategoria or None)
                     self.send_json_response(frases)
                 else:
-                    self.send_error(400, "URL malformada")
+                    categoria = urllib.parse.unquote(path_parts[2]) if len(path_parts) >= 3 else None
+                    subcategoria = urllib.parse.unquote(path_parts[3]) if len(path_parts) >= 4 else None
+                    categoria = categoria or None
+                    subcategoria = subcategoria or None
+                    frases = self.automation_server.get_frases(categoria, subcategoria)
+                    self.send_json_response(frases)
             else:
                 self.send_error(404, "Página não encontrada")
         except Exception as e:


### PR DESCRIPTION
## Summary
- normalize GET request parsing to ignore query strings and safely split path segments
- allow `/api/frases` to list data with optional `categoria`/`subcategoria` filters supplied either by path or query string
- guard the subcategory endpoint against missing category names to avoid confusing responses

## Testing
- python3 -m py_compile ServidorCode

------
https://chatgpt.com/codex/tasks/task_e_68cf8a1c86e4832f8cb9dc7da09cb80e