### PR TITLE
Destroy Tk root before launching webview

### DIFF
--- a/ClienteWindows
+++ b/ClienteWindows
@@ -280,6 +280,9 @@ class WindowsDesktopClient:
         if not WEBVIEW_AVAILABLE:
             return
         self.pending_webview = True
+        if self.root:
+            self.root.destroy()
+            self.root = None
         self.webview_window = webview.create_window(
             "Automação Médica - Dr. Alessandra Morais",
             self.pi_url,
@@ -287,7 +290,6 @@ class WindowsDesktopClient:
             height=700,
             resizable=True,
         )
-        self.root.quit()
 
     def is_pi_reachable(self, timeout=3):
         """Verificar se a URL do Pi responde."""
@@ -836,7 +838,8 @@ class WindowsDesktopClient:
             return
 
         try:
-            self.root.mainloop()
+            if self.root:
+                self.root.mainloop()
         except KeyboardInterrupt:
             pass
         finally:

--- a/ClienteWindows2
+++ b/ClienteWindows2
@@ -301,6 +301,9 @@ class WindowsDesktopClient:
         if not WEBVIEW_AVAILABLE:
             return
         self.pending_webview = True
+        if self.root:
+            self.root.destroy()
+            self.root = None
         self.webview_window = webview.create_window(
             "Automação Médica - Dr. Alessandra Morais",
             self.pi_url,
@@ -308,7 +311,6 @@ class WindowsDesktopClient:
             height=700,
             resizable=True,
         )
-        self.root.quit()
 
     def is_pi_reachable(self, timeout=3):
         """Verificar se a URL do Pi responde."""
@@ -857,7 +859,8 @@ class WindowsDesktopClient:
             return
 
         try:
-            self.root.mainloop()
+            if self.root:
+                self.root.mainloop()
         except KeyboardInterrupt:
             pass
         finally:


### PR DESCRIPTION
## Summary
- destroy the Tk fallback window before spinning up the pywebview UI in both Windows client variants
- guard the Tk main loop so it is skipped after the fallback window has been destroyed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddf4262908832fa01c13ca8ea3b1f4