### PR TITLE
Normalize indentation in MedicalAutomationServer methods

### DIFF
--- a/ServidorCode2
+++ b/ServidorCode2
@@ -12,12 +12,12 @@ import urllib.parse
 import traceback
 
 class MedicalAutomationServer:
-      def __init__(self, db_path=None):
+    def __init__(self, db_path=None):
         self.base_dir = os.path.dirname(os.path.abspath(__file__))
         self.db_path = self.resolve_database_path(db_path)
         self.verify_database()
 
-      def resolve_database_path(self, preferred_path):
+    def resolve_database_path(self, preferred_path):
         """Determina o caminho do banco considerando múltiplas possibilidades."""
         candidates = []
 


### PR DESCRIPTION
## Summary
- normalize the indentation of MedicalAutomationServer method definitions to a consistent four-space width

## Testing
- python3 ServidorCode2

------
https://chatgpt.com/codex/tasks/task_e_68e29d6afd48832faeff43ab66bf2fad