### PR TITLE
docs: add server setup instructions and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Ambas as versões expõem a interface em `http://pi.local:8080` (ou `http://<ip-
 - `DB_PATH`: caminho absoluto para o arquivo `automation.db` utilizado pelo `ServidorCode`.
 - `AUTOMATION_DB_PATH`: caminho preferencial para o banco no `ServidorCode2` (se ausente, ele volta para `DB_PATH`).
 
-Se nenhuma variável estiver definida, ambos os servidores tentam utilizar `/home/pi/automation.db`. A versão 2 também procura automaticamente por arquivos como `automation.db` ou `database/automation.db` no diretório do script e no diretório pai.
+Se nenhuma variável estiver definida, o `ServidorCode` utiliza como padrão `/home/pi/automation.db`. A versão 2, por sua vez, procura automaticamente por arquivos como `automation.db` ou `database/automation.db` no diretório do script e no diretório pai.
 
 ### Preparando o banco `automation.db`
 

--- a/README.md
+++ b/README.md
@@ -64,3 +64,49 @@ py ClienteWindows
 ---
 
 Para executar diretamente a interface web sem o cliente desktop, acesse `http://pi.local:8080` a partir de um navegador moderno conectado à mesma rede.
+
+## Servidor Web Raspberry Pi
+
+### Requisitos
+
+1. **Python 3.10+** (testado no Raspberry Pi OS Bookworm)
+2. Banco SQLite populado com o conteúdo do repositório (veja seção a seguir)
+
+### Executando o servidor
+
+Escolha o script desejado:
+
+| Script          | Comando                 | Porta padrão |
+|-----------------|-------------------------|--------------|
+| `ServidorCode`  | `python3 ServidorCode`  | `8080`       |
+| `ServidorCode2` | `python3 ServidorCode2` | `8080`       |
+
+Ambas as versões expõem a interface em `http://pi.local:8080` (ou `http://<ip-do-pi>:8080`).
+
+### Variáveis de ambiente e caminhos do banco
+
+- `DB_PATH`: caminho absoluto para o arquivo `automation.db` utilizado pelo `ServidorCode`.
+- `AUTOMATION_DB_PATH`: caminho preferencial para o banco no `ServidorCode2` (se ausente, ele volta para `DB_PATH`).
+
+Se nenhuma variável estiver definida, ambos os servidores tentam utilizar `/home/pi/automation.db`. A versão 2 também procura automaticamente por arquivos como `automation.db` ou `database/automation.db` no diretório do script e no diretório pai.
+
+### Preparando o banco `automation.db`
+
+1. Copie o repositório para o Raspberry Pi (incluindo os arquivos `SQL_File` e `SQL_2`).
+2. Gere o banco de dados a partir do SQL principal:
+
+   ```bash
+   sqlite3 automation.db < SQL_File
+   ```
+
+3. Opcional: importe complementos contidos em `SQL_2` executando novamente `sqlite3 automation.db < SQL_2`.
+4. Mova o arquivo resultante para o caminho desejado (`/home/pi/automation.db`, `~/database/automation.db`, etc.) e ajuste `DB_PATH`/`AUTOMATION_DB_PATH` conforme necessário.
+
+> 💡 O `ServidorCode2` tenta criar automaticamente o banco ao detectar `SQL_File`, `SQL_File.sql` ou arquivos equivalentes nos diretórios `.` ou `./database`. Ainda assim, manter o processo manual documentado garante repetibilidade em ambientes limpos.
+
+### Checklist de verificação
+
+1. Inicie o servidor desejado (`python3 ServidorCode2`).
+2. No navegador, acesse `http://pi.local:8080` (ou o IP informado no terminal) e confirme se as categorias são carregadas na barra lateral.
+3. Se o banco não carregar, confirme o caminho definido em `DB_PATH`/`AUTOMATION_DB_PATH` e verifique se `automation.db` contém a tabela `frases` com registros (`sqlite3 automation.db "SELECT COUNT(*) FROM frases;"`).
+


### PR DESCRIPTION
## Summary
- document the steps to launch ServidorCode/ServidorCode2 with the required Python version and default port
- explain the supported database environment variables and how to bootstrap automation.db from the SQL files
- add a troubleshooting checklist for validating that categories load in the web UI

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e2ab80d260832f8d23b60b7cc2642d